### PR TITLE
Simplify .install and auto-enable service on installation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ license=('MIT')
 depends=('python' 'python-evdev' 'python-pyudev')
 backup=('etc/middle-good-scrolling.conf')
 install="${pkgname}.install"
-source=("middle-good-scrolling"
+source=("middle-good-scrolling.py"
         "middle-good-scrolling.service"
         "middle-good-scrolling.conf")
 sha256sums=('SKIP'
@@ -17,8 +17,8 @@ sha256sums=('SKIP'
             'SKIP')
 
 package() {
-    # Install the main script
-    install -Dm755 "${srcdir}/middle-good-scrolling" "${pkgdir}/usr/bin/middle-good-scrolling"
+    # Install the main script (without .py extension)
+    install -Dm755 "${srcdir}/middle-good-scrolling.py" "${pkgdir}/usr/bin/middle-good-scrolling"
 
     # Install systemd service
     install -Dm644 "${srcdir}/middle-good-scrolling.service" "${pkgdir}/usr/lib/systemd/system/middle-good-scrolling.service"

--- a/middle-good-scrolling.install
+++ b/middle-good-scrolling.install
@@ -1,49 +1,14 @@
 post_install() {
-    echo ""
-    echo "==> middle-good-scrolling has been installed!"
-    echo ""
-    echo "To start using middle-click scrolling:"
-    echo "  1. Enable and start the service:"
-    echo "     sudo systemctl enable --now middle-good-scrolling.service"
-    echo ""
-    echo "  2. Check the status:"
-    echo "     sudo systemctl status middle-good-scrolling.service"
-    echo ""
-    echo "  3. View logs if needed:"
-    echo "     sudo journalctl -u middle-good-scrolling.service -f"
-    echo ""
-    echo "Configuration:"
-    echo "  - System-wide: /etc/middle-good-scrolling.conf"
-    echo "  - Per-user: ~/.config/middle-good-scrolling.conf"
-    echo ""
-    echo "After editing config, restart the service:"
-    echo "  sudo systemctl restart middle-good-scrolling.service"
-    echo ""
+    systemctl enable --now middle-good-scrolling.service
 }
 
 post_upgrade() {
-    echo ""
-    echo "==> middle-good-scrolling has been upgraded!"
-    echo ""
-    echo "Restart the service to apply changes:"
-    echo "  sudo systemctl restart middle-good-scrolling.service"
-    echo ""
+    # Restart if already running to use the new version
+    if systemctl is-active --quiet middle-good-scrolling.service; then
+        systemctl restart middle-good-scrolling.service
+    fi
 }
 
 pre_remove() {
-    if systemctl is-active --quiet middle-good-scrolling.service; then
-        systemctl stop middle-good-scrolling.service
-    fi
-    if systemctl is-enabled --quiet middle-good-scrolling.service; then
-        systemctl disable middle-good-scrolling.service
-    fi
-}
-
-post_remove() {
-    echo ""
-    echo "==> middle-good-scrolling has been removed."
-    echo ""
-    echo "Configuration files have been left in place:"
-    echo "  - /etc/middle-good-scrolling.conf.pacsave (if modified)"
-    echo ""
+    systemctl disable --now middle-good-scrolling.service 2>/dev/null || true
 }


### PR DESCRIPTION
Changes:
- Auto-enable and start service in post_install (breaks Arch convention intentionally - this package is useless without the service running)
- Auto-restart service on upgrade if already running
- Clean up service on removal with disable --now
- Remove all verbose instructional messages
- Fix PKGBUILD source to reference middle-good-scrolling.py

The package's sole purpose is the background service, so requiring manual enablement adds friction without benefit.