### PR TITLE
supports configuring the choice of activation button, as a list of fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # defter scrolling
 
-A better way of scrolling for the mouse. Makes it so that clicking a mouse button (by default, the middle mouse button) and dragging (anywhere on the page) is like clicking and dragging the scrollbar handle. This has a couple of advantages. Typically, the leverage of the scroll handle varies wildly depending on the length of the page, sometimes a scroll tab will be very small and so any mouse motion will translate to far too much view movement. Our belief is that the leverage of a scroll tab should be consistent, it shouldn't depend on the size of the page. Some few apps (eg, ripcord) adhere to this principle, implementing their own special scrollbar. If every app had made this choice, we wouldn't consider this package to be necessary. Alas.
+A better way of scrolling for your mouse: Makes it so that clicking your chosen mouse button and dragging (anywhere on the page) is like clicking and dragging the scrollbar handle (but better in various ways, see below). Many desktop environments offer functionality like this with middle click, but we allow (and recommend, and, by default, will be, if possible) binding it to a more comfortable button like the forward button, if you have one. Our implementation is also just more carefully tuned (feels less sticky, or rigid) and we're generally easier to configure than libinput stuff (*last we checked (late 2025) configuring libinput's middle click scroll behavior is currently difficult or impossible on wayland-kde*)
 
-This package also gives you horizontal scrolling (*and we do a special thing to prevent unintentional horizontal scroll movement from going through, code search "accumulator_vector" if you want the details*), which is a step up from most scroll wheels.
+We also give you horizontal scrolling (*and we have a special technique to prevent unintentional horizontal scroll movement from going through without preventing you from engaging in intentional biaxial movement, code search "accumulator_vector" if you want the details*).
 
-The activation button is configurable - you can use the middle button (default), back button, forward button, or any other mouse button. You can even specify a comma-separated list of buttons, and it will use the first one your mouse supports (perfect for mixed hardware setups).
+### conventional ways of scrolling that *defter scrolling* is definitely better than:
 
-If you need to use the activation button for its normal function (e.g., middle click), just do so without moving the mouse.
+- Grabbing and dragging the scroll handle: Usually, the handle movement to page movement ratio of the average scrollbar varies wildly depending on the length of the page, sometimes a scroll tab will be a little sliver and so any mouse motion will produce far too much page movement, leading to unpredictable and uncontrollable scrolling. It's not like that with this.
 
-If any of your apps need to be able to distinguish the activation button's down event from up event, this package will break that, it delays the button down event until you (without moving/initiating a scroll) release the button (*if we didn't, an unwanted or unmatched button down event would fire every time the user wants to scroll. Not everyone knows this, but if you send a button down event without ever sending an up event it breaks all clicking.*), but apps that care about this distinction are rare, and often they provide other ways of doing whatever they used that for. There's a reason this is rarely a problem; windows long ago standardized another (generally worse) middle click drag behaviour, which we're replacing, so any app compatible with windows will be compatible with this. Some graphics apps use middle click drag to pan, but middle click scroll (what we're providing) is functionally equivalent to that! And many of these apps also bind that functionality to space-drag or some other keyboard input, which is just as good.
+- Mouse wheel: Most are not very good, only scroll in small increments. If you have a rare good mouse wheel, see below.
+
+### Other ways of scrolling that *defter scrolling* isn't necessarily better than:
+
+- Trackpad two-finger scroll: If you have one of these you don't need defter scrolling imo.
+
+- *Analog* mouse wheels: Unsure, I'd say these are only slightly worse than defter scrolling. There are some analog mouse wheels that can spin freely with low friction, those are okay. They don't support horizontal scrolling, and flicking the wheel with your finger isn't really as ergonomic or controllable as just moving the mouse normally, so I still think they're worse on net.
+
+Generally, defter scrolling wont interfere with other uses of the assigned button, since we only absorb the activation button click if you begin a drag. This will interfere with apps that use drags with that button, but such cases are very rare, and even in these cases (*eg, some graphics apps use middle-click scroll to pan the page*) apps generally provide alternative ways of doing those things (*letting you pan by pressing space instead, which I've always thought was really nice*).
 
 ## Install
 
@@ -25,7 +33,7 @@ systemctl enable --now defter-scrolling
 
 Dunno. Might do a debian/ubuntu version soon.
 
-If people like it I think it should probably be part of KDE or something. - oh... Embarrassingly, only after making this did I realize KDE/libinput already basically has middle click scroll. Regardless, our implementation is way nicer, as things currently stand. Libinput has horrible defaults (very high initial friction, low scroll speed), gets stuck going either horizontal or vertical and can't do both at once (we have a more intelligent approach to this), if any of this is changeable, I have no idea where the configuration files are, and according to libinput, on wayland, there might not even be a configuration file for this stuff, it has to be exposed by the desktop environment, and KDE's graphics settings dialog certainly doesn't expose them currently, and if they're exposed in the settings, I again have no idea where they are.
+I'd like to get this implementation into libinput, if you could help with that it would be greatly appreciated.
 
 ## Configuration and Management
 
@@ -37,15 +45,10 @@ Config example (this is the default):
 
 ```ini
 [Settings]
-# The mouse button(s) that activate scrolling
-# Can be a single button or comma-separated list (tries each in order)
-# Options: middle, back, forward, left, right
-# Examples:
-#   activation_button = middle          # Use middle button
-#   activation_button = back, middle    # Use back button if available, otherwise middle
-#   activation_button = forward, back   # Use forward if available, otherwise back
-# Default: middle
-activation_button = middle
+# The mouse buttons that can activate scrolling. Only the first one that is present on the mouse will be used, the rest are fallbacks.
+# We recommend setting this to 'forward' if you have it (this is the default) (forward is usually more comfortable to click, and it's used less often, and apps never use it for drag actions), but not everyone has it, so the default setting will fall back to 'back' after that, and if you don't have that, 'middle', and if you don't have middle, it'll default to 'right'.
+# Options: middle, back_proper, back (which is officially called BTN_SIDE), forward_proper, forward (which is officially called BTN_EXTRA), left, right, You can also use any of the standard linux/input.h button codes.
+activation_buttons = BTN_FORWARD, forward, back, middle, right
 
 # Scroll speed multiplier
 # Higher values = faster scrolling

--- a/defter-scrolling
+++ b/defter-scrolling
@@ -12,78 +12,48 @@ from dataclasses import dataclass
 import time
 
 
-def get_button_code(button_name: str) -> int:
-    """Map a single button name to evdev button code"""
-    button_map = {
-        'middle': e.BTN_MIDDLE,
-        'back': e.BTN_SIDE,      # Also known as BTN_BACK or mouse button 4
-        'forward': e.BTN_EXTRA,   # Also known as BTN_FORWARD or mouse button 5
-        'left': e.BTN_LEFT,
-        'right': e.BTN_RIGHT,
-    }
-
+button_name_to_code_map = {
+    'middle': e.BTN_MIDDLE,
+    'back': e.BTN_SIDE,
+    'forward': e.BTN_EXTRA,
+    'left': e.BTN_LEFT,
+    'right': e.BTN_RIGHT,
+}
+button_code_to_name_map = {v: k for k, v in button_name_to_code_map.items()}
+def get_button_code(button_name: str) -> int | None:
     button_name_lower = button_name.lower().strip()
-    if button_name_lower in button_map:
-        return button_map[button_name_lower]
+    if button_name_lower in button_name_to_code_map:
+        return button_name_to_code_map[button_name_lower]
     else:
-        return None
+        return e.ecodes.get(button_name_lower)
 
+def get_button_name(button_code: int) -> str | None:
+    if button_code in button_code_to_name_map:
+        return button_code_to_name_map[button_code]
+    else:
+        return e.BTN.get(button_code, None)
 
-def parse_button_names(button_string: str) -> list[str]:
-    """Parse comma-separated button names from config"""
-    if not button_string:
-        return ['middle']
-
-    # Split by comma and strip whitespace
-    buttons = [b.strip() for b in button_string.split(',')]
-    # Filter out empty strings
-    buttons = [b for b in buttons if b]
-
-    return buttons if buttons else ['middle']
-
-
-def select_activation_button(button_names: list[str], mouse_capabilities: list[int]) -> tuple[int, str]:
-    """
-    Select the first available button from the list that the mouse has.
-    Returns a tuple of (button_code, button_name).
-    Falls back to middle button if none of the requested buttons are available.
-    """
+def select_first_present_activation_button(button_codes: list[int], mouse_capabilities: list[int]) -> int | None:
     # Warn about invalid button names
-    for button_name in button_names:
-        button_code = get_button_code(button_name)
+    for button_code in button_codes:
         if button_code is None:
-            print(f"Warning: Unknown button name '{button_name}', skipping")
+            print(f"Warning: Unknown button code '{get_button_name(button_code) or button_code}', skipping")
+    
+    for code in button_codes:
+        if code in mouse_capabilities:
+            return code
 
-    # Select the first valid and available button
-    for button_name in button_names:
-        button_code = get_button_code(button_name)
-        if button_code is not None and button_code in mouse_capabilities:
-            return (button_code, button_name)
-
-    # Fallback: try middle button even if not in the list
-    if e.BTN_MIDDLE in mouse_capabilities:
-        print(f"Warning: None of the requested buttons {button_names} are available, falling back to 'middle'")
-        return (e.BTN_MIDDLE, 'middle')
-
-    # Last resort: use the first available standard mouse button
-    for btn_code, btn_name in [(e.BTN_LEFT, 'left'), (e.BTN_RIGHT, 'right'), (e.BTN_MIDDLE, 'middle')]:
-        if btn_code in mouse_capabilities:
-            print(f"Warning: None of the requested buttons {button_names} are available, falling back to '{btn_name}'")
-            return (btn_code, btn_name)
-
-    # This should never happen, but just in case
-    print(f"Warning: Could not find any suitable button, defaulting to middle")
-    return (e.BTN_MIDDLE, 'middle')
+    print(f"Warning: The mouse had none of the buttons that were assigned by the config, the functionality will be inactive.")
+    return None
 
 
 # ideally most of this would be measured in mms rather than pixels, I haven't looked into it. Generally, computers don't give you accurate mms per pixel. Device manufacturers (and desktop environments) are in a state of sin and don't even try to provide it. So we just use pixels.
 @dataclass
 class Config:
-    # The mouse button that activates scrolling
-    # We recommend setting this to 'forward' if you have it (It's usually more comfortable to click, and less often used, and never used by apps for drag actions), but not everyone has it, so the default is middle.
-    # Options: middle, back, forward, left, right
-    # Default: middle
-    activation_button: str = 'middle'
+    # The mouse buttons that can activate scrolling. Only the first one that is present on the mouse will be used, the rest are fallbacks.
+    # We recommend setting this to 'forward' if you have it (It's usually more comfortable to click, and it's used less often, and apps never use it for drag actions), but not everyone has it, so it defaults to middle after that, and if you don't have middle, it'll default to right click.
+    # Options: middle, back_proper, back (which is officially called BTN_SIDE), forward_proper, forward (which is officially called BTN_EXTRA), left, right, You can also use any of the standard linux/input.h button codes.
+    activation_buttons: tuple[int, ...] = (e.BTN_FORWARD, e.BTN_EXTRA, e.BTN_SIDE, e.BTN_MIDDLE, e.BTN_RIGHT)
     # Scroll speed multiplier
     # Higher values = faster scrolling
     scroll_speed: float = 30.0
@@ -104,7 +74,6 @@ class Config:
     accumulator_vector_limit: float = 10.0
 
 def load_config() -> Config:
-    """Load configuration from file or use defaults"""
     config = Config()
     config_paths = [
         '/etc/defter-scrolling.conf',
@@ -128,7 +97,16 @@ def load_config() -> Config:
                     take('vertical_movement_threshold', ps.getfloat)
                     take('accumulator_vector_limit', ps.getfloat)
                     take('enable', ps.getboolean)
-                    take('activation_button', ps.get)
+                    button_string = ps.get('activation_buttons')
+                    if button_string:
+                        button_codes = []
+                        for b in button_string.split(','):
+                            button_code = get_button_code(b.strip())
+                            if button_code is not None:
+                                button_codes.append(button_code)
+                            else:
+                                print(f"Warning: Unknown button name '{b.strip()}', skipping")
+                        config.activation_buttons = tuple(button_codes)
                 print(f"Loaded config from: {path}")
                 break
             except Exception as ex:
@@ -141,8 +119,8 @@ def load_config() -> Config:
 
 @dataclass
 class State:
-    """Shared state for mouse event handling across threads"""
-    middle_pressed: bool = False
+    # Shared state for mouse event handling across threads
+    button_pressed: bool = False
     accumulator_vector: tuple[float, float] = (0.0, 0.0)
     has_started_horizontal_scroll: bool = False
     has_started_vertical_scroll: bool = False
@@ -174,7 +152,6 @@ def scroll_speed_for(distance_traveled: float, config: Config) -> int:
     return int(round(config.scroll_speed * distance_traveled * (-1 if config.invert_scroll else 1)))
 
 def find_all_mice():
-    """Find all mouse devices using udev for proper device classification"""
     context = pyudev.Context()
     mice = []
 
@@ -202,7 +179,7 @@ def find_all_mice():
                 input_device = evdev.InputDevice(device.device_node)
                 # Double-check that it has mouse buttons
                 caps = input_device.capabilities().get(e.EV_KEY, [])
-                if any(btn in caps for btn in [e.BTN_LEFT, e.BTN_RIGHT, e.BTN_MIDDLE]):
+                if any(btn in caps for btn in [e.BTN_LEFT, e.BTN_RIGHT]):
                     mice.append(input_device)
                     print(f"Found mouse: {input_device.name} ({input_device.path})")
             except (OSError, PermissionError) as ex:
@@ -211,17 +188,11 @@ def find_all_mice():
 
     return mice
 
-def handle_mouse(mouse, ui, shared_state, config):
+def handle_mouse(mouse, ui, shared_state: State, config: Config):
     print(f"Listening to: {mouse.name} ({mouse.path})")
-
-    # Parse the configured activation buttons (can be comma-separated)
-    button_names = parse_button_names(config.activation_button)
-
     # Get the mouse's capabilities and select the first available button
     mouse_capabilities = mouse.capabilities().get(e.EV_KEY, [])
-    activation_button_code, selected_button_name = select_activation_button(button_names, mouse_capabilities)
-
-    print(f"  Using '{selected_button_name}' button for activation on {mouse.name}")
+    activation_button_code = select_first_present_activation_button(config.activation_buttons, mouse_capabilities)
 
     # Grab the device to intercept all events
     try:
@@ -235,13 +206,12 @@ def handle_mouse(mouse, ui, shared_state, config):
             if event.type == e.EV_KEY and event.code == activation_button_code:
                 with shared_state.lock:
                     if event.value == 1:
-                        shared_state.middle_pressed = True
-                        # Don't forward the press event, only send a middle click when we know we're not scrolling (on release)
+                        shared_state.button_pressed = True
+                        # Don't forward the press event, only send the click when we know we're not scrolling (on release)
                     elif event.value == 0:
-                        was_pressed = shared_state.middle_pressed
+                        was_pressed = shared_state.button_pressed
                         drag_magnitude = magnitude(shared_state.accumulator_vector)
-                        has_scrolled = shared_state.has_started_horizontal_scroll or shared_state.has_started_vertical_scroll
-                        shared_state.middle_pressed = False
+                        shared_state.button_pressed = False
                         shared_state.has_started_horizontal_scroll = False
                         shared_state.has_started_vertical_scroll = False
                         shared_state.accumulator_vector = (0.0, 0.0)
@@ -254,7 +224,7 @@ def handle_mouse(mouse, ui, shared_state, config):
 
             elif event.type == e.EV_REL:
                 with shared_state.lock:
-                    if shared_state.middle_pressed:
+                    if shared_state.button_pressed:
                         # Convert mouse movement to scroll events
                         # I don't know why but it seems like we have to invert the vertical scroll direction but not the horizontal. Maybe mouse and X11 coordinates are vertically flipped?
                         if event.code == e.REL_X:
@@ -322,7 +292,7 @@ def handle_mouse(mouse, ui, shared_state, config):
         except:
             pass  # Device might already be gone
 
-def monitor_devices(ui, shared_state, config, active_threads, active_threads_lock, stop_event, virtual_device_path):
+def monitor_devices(ui, shared_state:State, config:Config, active_threads, active_threads_lock, stop_event, virtual_device_path):
     """Monitor for device connection/disconnection events"""
     print("Starting device monitor...")
     context = pyudev.Context()
@@ -367,7 +337,7 @@ def monitor_devices(ui, shared_state, config, active_threads, active_threads_loc
 
                 # Check that it has mouse buttons
                 caps = input_device.capabilities().get(e.EV_KEY, [])
-                if any(btn in caps for btn in [e.BTN_LEFT, e.BTN_RIGHT, e.BTN_MIDDLE]):
+                if any(btn in caps for btn in [e.BTN_LEFT, e.BTN_RIGHT]):
                     # Double-check it's not already being handled (race condition check)
                     with active_threads_lock:
                         if input_device.path in active_threads:
@@ -401,7 +371,6 @@ def monitor_devices(ui, shared_state, config, active_threads, active_threads_loc
 def main():
     # Load configuration
     config = load_config()
-    print(f"Configuration: activation_button={config.activation_button}, drag_slop={config.drag_slop}, scroll_speed={config.scroll_speed}, invert_scroll={config.invert_scroll}")
     
     if not config.enable:
         print("defter scrolling has 'enabled' set to false in configuration, exiting.")
@@ -460,8 +429,11 @@ def main():
     monitor_thread.daemon = True
     monitor_thread.start()
 
-    button_names = parse_button_names(config.activation_button)
-    if len(button_names) > 1:
+    button_names = [get_button_name(code) for code in config.activation_buttons]
+    if len(button_names) == 0:
+        print(f"Warning: No activation buttons found, the functionality will be inactive.")
+    elif len(button_names) > 1:
+        print(button_names)
         print(f"\n=== Ready! Configured button priority: {', '.join(button_names)} ===")
     else:
         print(f"\n=== Ready! Hold {button_names[0]} button and move mouse ===")

--- a/defter-scrolling.conf
+++ b/defter-scrolling.conf
@@ -1,17 +1,8 @@
 [Settings]
-# The mouse button(s) that activate scrolling
-# Can be a single button or comma-separated list (tries each in order)
-# Options: middle, back, forward, left, right
-# We recommend setting this to 'forward, middle' if you have forward button
-# (forward is usually more comfortable to click, less often used, and never
-# used by apps for drag actions), with middle as fallback for mice without it.
-# Examples:
-#   activation_button = middle          # Use middle button
-#   activation_button = forward, middle # Use forward if available, otherwise middle
-#   activation_button = back, middle    # Use back button if available, otherwise middle
-#   activation_button = forward, back   # Use forward if available, otherwise back
-# Default: middle
-activation_button = 'middle'
+# The mouse buttons that can activate scrolling. Only the first one that is present on the mouse will be used, the rest are fallbacks.
+# We recommend setting this to 'forward' if you have it (this is the default) (forward is usually more comfortable to click, and it's used less often, and apps never use it for drag actions), but not everyone has it, so the default setting will fall back to 'back' after that, and if you don't have that, 'middle', and if you don't have middle, it'll default to 'right'.
+# Options: middle, back_proper, back (which is officially called BTN_SIDE), forward_proper, forward (which is officially called BTN_EXTRA), left, right, You can also use any of the standard linux/input.h button codes.
+activation_buttons = BTN_FORWARD, forward, back, middle, right
 
 # Scroll speed multiplier
 # Higher values = faster scrolling


### PR DESCRIPTION
you can now list any libinput button code name as a preferred activation button (previously it was just middle click), and if the mouse doesn't have that button, we traverse down the list of options and use the first one it has.

The default activation button is now the forward button.